### PR TITLE
stop and restart task on live event toggle

### DIFF
--- a/hacker-news-api/src/main.rs
+++ b/hacker-news-api/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Error> {
     //     );
     // }
 
-    let mut rx = subscribe_top_stories();
+    let (mut rx, _) = subscribe_top_stories();
 
     let mut old_keys = Vec::new();
 


### PR DESCRIPTION
Completely disable the async task when live events are toggled and start a new task when re-enabling.